### PR TITLE
x86_64-linuxプラットフォームをGemfile.lockに追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
     oauth (1.1.2)
       oauth-tty (~> 1.0, >= 1.0.6)
       snaky_hash (~> 2.0)
@@ -192,6 +194,7 @@ GEM
       snaky_hash (~> 2.0, >= 2.0.3)
       version_gem (~> 1.1, >= 1.1.9)
     pg (1.6.2-aarch64-linux)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -293,6 +296,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
## 概要
x86_64-linuxプラットフォームをGemfile.lockに追加