### PR TITLE
カテゴリ別ページへ遷移

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,16 +18,19 @@
         <% end %>
         <div class="card-body">
           <h1 class="card-title h2 mb-3"><%= @post.title %></h1>
-
-          <% if @post.categories.any? %> <!--カテゴリー表示-->
-            <div class="mb-3">
+          <div class="mb-3">
+            <% if @post.categories.any? %>
               <% @post.categories.each do |category| %>
-                <span class="badge bg-primary me-1 mb-1">
+                <%= link_to posts_path(category: category.id), class: "badge bg-primary text-decoration-none me-1 mb-1" do %>
                   <i class="bi bi-tag"></i> <%= category.name %>
-                </span>
+                <% end %>
               <% end %>
-            </div>
-          <% end %>
+            <% else %>
+              <span class="badge bg-secondary me-1 mb-1">
+                <i class="bi bi-tag"></i> 未分類
+              </span>
+            <% end %>
+          </div>
 
           <div class="d-flex align-items-center mb-4 text-muted">
             <i class="bi bi-person-circle me-2"></i>


### PR DESCRIPTION
## 概要
投稿詳細のカテゴリ表示をクリックすると、そのカテゴリ別ページへ遷移できるようにしました
## レビューポイント
投稿詳細画面でカテゴリ情報が見れるかどうか
カテゴリ名をクリックすると、そのカテゴリの投稿一覧ページに遷移するかどうか
カテゴリが未設定の場合、適切な表示がされる（未分類）かどうか
スマホでも適切に表示されるかどうか