### PR TITLE
画像が表示されないエラー解決

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -33,7 +33,7 @@ module PostsHelper
 
     variant = post.image.variant(
       resize_to_limit: [1200, 800],
-      format: :webp,
+      format: :webp
     ).processed
 
     # デフォルトのクラスとスタイル


### PR DESCRIPTION
## 概要
画像が表示されないエラーを解決するために、画像形式をwebpに変換する際のqualityの指定を削除