### PR TITLE
画像がない場合にyoutubeサムネを表示する

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -33,4 +33,61 @@ module PostsHelper
     Rails.logger.error "Error in post_image_tag: #{e.message}"
     nil # エラー時もnilを返して画像部分を非表示にする
   end
+
+  def post_thumbnail_tag(post, html_options: {}, placeholder_height: '200px')
+    if post&.image&.attached?
+      return post_image_tag(post, html_options: html_options, placeholder_height: placeholder_height)
+    end
+
+    if post&.youtube_url.present?
+      youtube_id = extract_youtube_id(post.youtube_url)
+      if youtube_id
+        return youtube_thumbnail_tag(youtube_id, post.title, html_options: html_options,
+                                                             placeholder_height: placeholder_height)
+      end
+    end
+
+    nil
+  end
+
+  # YouTube動画IDを抽出
+  def extract_youtube_id(url)
+    return nil if url.blank?
+
+    patterns = [
+      %r{(?:youtube\.com/watch\?v=|youtu\.be/)([^&?/]+)},
+      %r{youtube\.com/embed/([^&?/]+)},
+      %r{youtube\.com/v/([^&?/]+)}
+    ]
+
+    patterns.each do |pattern|
+      match = url.match(pattern)
+      return match[1] if match
+    end
+
+    nil
+  end
+
+  # YouTubeサムネイル画像を表示
+  def youtube_thumbnail_tag(video_id, alt_text = '', html_options: {}, placeholder_height: '200px')
+    thumbnail_url = "https://img.youtube.com/vi/#{video_id}/hqdefault.jpg"
+
+    default_class = 'card-img-top img-fluid'
+    default_style = "object-fit: cover; max-height: #{placeholder_height}; width: 100%;"
+
+    custom_class = html_options.delete(:class) || ''
+    custom_style = html_options.delete(:style) || ''
+
+    merged_class = [default_class, custom_class].compact_blank.join(' ')
+    merged_style = custom_style.presence || default_style
+
+    default_options = {
+      class: merged_class,
+      style: merged_style,
+      alt: alt_text,
+      loading: 'lazy'
+    }
+
+    image_tag(thumbnail_url, default_options.merge(html_options))
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -75,8 +75,8 @@
     <% @posts.each do |post| %>
       <div class="col-md-6 col-lg-4">
         <div class="card h-100 shadow-sm">
-          <% if (image_html = post_image_tag(post, placeholder_height: "200px")) %>
-            <%= image_html %>
+          <% if (thumbnail_html = post_thumbnail_tag(post, placeholder_height: "200px")) %>
+            <%= thumbnail_html %>
           <% end %>
           <div class="card-body d-flex flex-column">
             <h5 class="card-title"><%= post.title %></h5>


### PR DESCRIPTION
## 概要
投稿内容に画像がある場合、投稿一覧画面には画像がサムネとして表示されており、画像がない場合はサムネが存在しなかったが、画像がなく、youtube動画のみがある場合、youtube動画のサムネが本投稿のサムネとして表示されるようにしました。